### PR TITLE
Add Event suggestions

### DIFF
--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -10,7 +10,7 @@ allprojects {
     version = "1.5.2-SNAPSHOT"
 
     java {
-        toolchain.languageVersion.set(JavaLanguageVersion.of(17))
+        toolchain.languageVersion.set(JavaLanguageVersion.of(21))
     }
 }
 
@@ -18,7 +18,7 @@ subprojects {
     tasks {
         withType<JavaCompile> {
             options.encoding = Charsets.UTF_8.name()
-            options.release.set(17)
+            options.release.set(21)
         }
         withType<Javadoc> {
             options.encoding = Charsets.UTF_8.name()

--- a/debuggery-bukkit/build.gradle.kts
+++ b/debuggery-bukkit/build.gradle.kts
@@ -1,11 +1,11 @@
 plugins {
     id("io.github.goooler.shadow")
-    id("xyz.jpenilla.run-paper") version "2.1.0"
+    id("xyz.jpenilla.run-paper") version "2.3.0"
 }
 
 tasks {
     processResources {
-        filesMatching("plugin.yml") {
+        filesMatching("paper-plugin.yml") {
             expand("version" to project.version)
         }
     }
@@ -20,13 +20,14 @@ tasks {
     }
 
     runServer {
-        minecraftVersion("1.20.1")
+        minecraftVersion("1.21")
     }
 }
 
 dependencies {
     implementation(project(":debuggery-common"))
-    compileOnly("io.papermc.paper:paper-api:1.20.1-R0.1-SNAPSHOT")
+    implementation("org.reflections:reflections:0.10.2");
+    compileOnly("io.papermc.paper:paper-api:1.21-R0.1-SNAPSHOT")
     testImplementation(project(path = ":debuggery-common", configuration = "testArchive"))
-    testImplementation("io.papermc.paper:paper-api:1.20.1-R0.1-SNAPSHOT")
+    testImplementation("io.papermc.paper:paper-api:1.21-R0.1-SNAPSHOT")
 }

--- a/debuggery-bukkit/src/main/java/io/zachbr/debuggery/DebuggeryBukkit.java
+++ b/debuggery-bukkit/src/main/java/io/zachbr/debuggery/DebuggeryBukkit.java
@@ -22,8 +22,10 @@ import io.zachbr.debuggery.commands.base.BukkitCommandBase;
 import io.zachbr.debuggery.reflection.types.handlers.bukkit.BukkitBootstrap;
 import io.zachbr.debuggery.util.EventDebugger;
 import org.bukkit.Bukkit;
+import org.bukkit.event.Event;
 import org.bukkit.plugin.java.JavaPlugin;
 import org.jetbrains.annotations.Nullable;
+import org.reflections.Reflections;
 
 import java.util.*;
 
@@ -34,11 +36,13 @@ public class DebuggeryBukkit extends DebuggeryBase {
     private UUID targetedEntity;
     private final DebuggeryJavaPlugin javaPlugin;
     private final Map<String, BukkitCommandBase> commands = new HashMap<>();
+    private final List<String> events;
 
     DebuggeryBukkit(DebuggeryJavaPlugin plugin, Logger logger) {
         super(logger);
         this.javaPlugin = plugin;
         this.eventDebugger = new EventDebugger(this);
+        events = new Reflections().getSubTypesOf(Event.class).stream().map(Class::getCanonicalName).toList();
     }
 
     void onEnable() {
@@ -108,5 +112,9 @@ public class DebuggeryBukkit extends DebuggeryBase {
 
     String getPlatformVersion() {
         return Bukkit.getVersion();
+    }
+
+    public List<String> getEvents() {
+        return events;
     }
 }

--- a/debuggery-bukkit/src/main/java/io/zachbr/debuggery/commands/EventCommand.java
+++ b/debuggery-bukkit/src/main/java/io/zachbr/debuggery/commands/EventCommand.java
@@ -70,6 +70,8 @@ public class EventCommand extends BukkitCommandReflection {
     public List<String> tabCompleteLogic(Audience sender, String[] args) {
         if (args.length == 0) {
             return List.of();
+        } else if (args.length == 1) {
+            return plugin.getEvents().stream().filter(s -> s.contains(args[0])).toList();
         }
         try {
             Class<?> event = Class.forName(args[0], true, this.getClass().getClassLoader());

--- a/debuggery-common/build.gradle.kts
+++ b/debuggery-common/build.gradle.kts
@@ -20,6 +20,12 @@ artifacts {
     add("testArchive", tasks.getByName("jarTest"))
 }
 
-blossom {
-    replaceToken("\$VERSION", project.version)
+sourceSets {
+    main {
+        blossom {
+            resources {
+                property("version", project.version.toString())
+            }
+        }
+    }
 }

--- a/debuggery-velocity/build.gradle.kts
+++ b/debuggery-velocity/build.gradle.kts
@@ -1,6 +1,6 @@
 plugins {
     id("io.github.goooler.shadow")
-    id("xyz.jpenilla.run-velocity") version "2.1.0"
+    id("xyz.jpenilla.run-velocity") version "2.3.0"
 }
 
 tasks {
@@ -16,6 +16,6 @@ tasks {
 
 dependencies {
     implementation(project(":debuggery-common"))
-    compileOnly("com.velocitypowered:velocity-api:3.2.0-SNAPSHOT")
-    annotationProcessor("com.velocitypowered:velocity-api:3.2.0-SNAPSHOT")
+    compileOnly("com.velocitypowered:velocity-api:3.3.0-SNAPSHOT")
+    annotationProcessor("com.velocitypowered:velocity-api:3.3.0-SNAPSHOT")
 }

--- a/settings.gradle.kts
+++ b/settings.gradle.kts
@@ -13,7 +13,7 @@ pluginManagement {
         mavenCentral()
     }
     plugins {
-        id("net.kyori.blossom") version "1.3.1"
+        id("net.kyori.blossom") version "2.1.0"
         id("io.github.goooler.shadow") version "8.1.7"
     }
 }


### PR DESCRIPTION
Adds event suggestions to paper (velocity doesn't have an general class all Events extend it seems). This does use a third party reflection library (because i am not willing to try and figure out how to do this myself) which we would either have to include in the jar or use the PluginLoader. I can understand if you don't want to use a library, in which case i will just keep this on my fork. 