### PR TITLE
Add event class tab completes to event command

### DIFF
--- a/settings.gradle.kts
+++ b/settings.gradle.kts
@@ -1,6 +1,6 @@
 dependencyResolutionManagement {
     repositories {
-        maven("https://papermc.io/repo/repository/maven-public/")
+        maven("https://repo.papermc.io/repository/maven-public/")
         maven("https://oss.sonatype.org/content/groups/public/")
         mavenCentral()
     }


### PR DESCRIPTION
Adds tab completes for the event command by using the same list of event classes that /paper dumplisteners also uses.

![image](https://github.com/user-attachments/assets/4660387f-5931-41b9-8744-0f7fb1009bc3)
